### PR TITLE
add restartsec parameter to systemd unit

### DIFF
--- a/templates/init/systemd/telegraf.service.j2
+++ b/templates/init/systemd/telegraf.service.j2
@@ -19,6 +19,7 @@ ExecStart        = /usr/bin/telegraf $OPTIONS
 
 SyslogIdentifier = telegraf
 Restart          = always
+RestartSec       = 3s
 RestartForceExitStatus = SIGPIPE
 KillMode         = control-group
 


### PR DESCRIPTION
Unfortunately Telegraf crashes completely if one of the plugins does not reach it's configured endpoint (or has any other error) at startup.
Apparently this is expected behavior for Telegraf (which I don't understand why but that's a different topic).

Luckily this can be mitigated by just automatically restarting the agent constantly if it fails to start.
However in the current setup created by this Ansible playbook this does not work properly due to a missing parameter in the systemd unit file.

When no RestartSec parameter is set, SystemD automatically tries to restart the service several times in 100ms intervals.
Unfortunately this triggers the "max restart retries" ratelimiter after a few restarts, causing SystemD to pretty much stall itself.
Once that ratelimit is reached the service is permanently stopped until it is manually restarted with the systemctl command.

Running into this ratelimit and causing SystemD to stall itself can be prevented by increasing the interval for the restart attempts.
Since there is no reason to try to restart the service every 100ms if it failed this can be set to a much higher value.

---

This PR is meant to fix this issue and adds the missing parameter to the SystemD unit.

3 seconds seemed like a sensible value for the restart interval to me here since this is more than enough for a system monitoring agent under normal circumstances.
